### PR TITLE
Create main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,3 @@
+galaxy_info:
+  author: Lex Rivera
+  description: Installs lm-sensors and starts it.


### PR DESCRIPTION
This should fix this error when installing the role with ansible-galaxy from a requirements file: 

`[WARNING]: - ansible-role-lm-sensors was NOT installed successfully: this role does not appear to have a meta/main.yml file.`